### PR TITLE
ISSUE-11: (bugfix) rebase support in commiticketing

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -3,6 +3,8 @@ on:
   push:
     branches:
     - 'main'
+    - 'feature/*'
+    - 'bugfix/*'
 
 jobs:
   sanity-run:

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -2,11 +2,10 @@ default_install_hook_types: [ commit-msg, pre-commit, prepare-commit-msg ]
 default_stages: [ pre-commit ]
 repos:
 -   repo: https://github.com/ShellMagick/shellmagick-commit-hooks
-    rev: 2ce96f38e4dd815ffd1378d0e8930a4f97a04af4
+    rev: v24.03
     hooks:
-    # We don't use commiticketing in this repo... yet!
-    #-   id: commiticketing
-    #    stages: [ prepare-commit-msg ]
+    -   id: commiticketing
+        stages: [ prepare-commit-msg ]
     -   id: no-boms
     -   id: no-todos
         args: [ -e=.pre-commit-hooks.yaml, -e=test_no_todos.py, -e=no_todos.py, -e=README.md, -e=CHANGELOG.md ]


### PR DESCRIPTION
Not testing interactive rebase, because it's just too cumbersome. Will test manually (from the testing perspective it should be the same as a non-interactive rebase).

Closes https://github.com/ShellMagick/commit-hooks/issues/11